### PR TITLE
fix: bundle

### DIFF
--- a/swift-gen/src/renderers/colorset_renderer.rs
+++ b/swift-gen/src/renderers/colorset_renderer.rs
@@ -14,6 +14,19 @@ impl Renderer for ColorSetRenderer {
     d.push_str("extension UIColor {\n");
     self.render_ruleset_into(ruleset, d, config);
     d.push_str("}\n");
+    d.push_str("\n");
+    d.push_str(
+r#"private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+"#
+    );
   }
 }
 
@@ -43,7 +56,7 @@ impl ColorSetRenderer {
     config: &RendererConfig,
   ) {
     d.push_str(&format!(
-      "{}{}static let {} = UIColor(named: \"{}\")!\n",
+      "{}{}static let {} = UIColor(named: \"{}\", in: BundleToken.bundle, compatibleWith: nil)!\n",
       config.indent(declaration.identifier.depth),
       config.access_level.to_string(),
       declaration.identifier.short,

--- a/swift-gen/tests/fixtures/colorset-public/UIColor+Custom.swift
+++ b/swift-gen/tests/fixtures/colorset-public/UIColor+Custom.swift
@@ -4,25 +4,35 @@ import UIKit
 
 extension UIColor {
   public enum Custom {
-    public static let LightContentSeparator = UIColor(named: "LightContentSeparator")!
+    public static let LightContentSeparator = UIColor(named: "LightContentSeparator", in: BundleToken.bundle, compatibleWith: nil)!
     public enum NumericInput {
-      public static let Background = UIColor(named: "NumericInputBackground")!
+      public static let Background = UIColor(named: "NumericInputBackground", in: BundleToken.bundle, compatibleWith: nil)!
       public enum DoneKey {
-        public static let Background = UIColor(named: "NumericInputDoneKeyBackground")!
-        public static let Highlight = UIColor(named: "NumericInputDoneKeyHighlight")!
-        public static let Shadow = UIColor(named: "NumericInputDoneKeyShadow")!
-        public static let Text = UIColor(named: "NumericInputDoneKeyText")!
+        public static let Background = UIColor(named: "NumericInputDoneKeyBackground", in: BundleToken.bundle, compatibleWith: nil)!
+        public static let Highlight = UIColor(named: "NumericInputDoneKeyHighlight", in: BundleToken.bundle, compatibleWith: nil)!
+        public static let Shadow = UIColor(named: "NumericInputDoneKeyShadow", in: BundleToken.bundle, compatibleWith: nil)!
+        public static let Text = UIColor(named: "NumericInputDoneKeyText", in: BundleToken.bundle, compatibleWith: nil)!
       }
       public enum NumericKey {
-        public static let Background = UIColor(named: "NumericInputNumericKeyBackground")!
-        public static let Highlight = UIColor(named: "NumericInputNumericKeyHighlight")!
-        public static let Shadow = UIColor(named: "NumericInputNumericKeyShadow")!
-        public static let Text = UIColor(named: "NumericInputNumericKeyText")!
+        public static let Background = UIColor(named: "NumericInputNumericKeyBackground", in: BundleToken.bundle, compatibleWith: nil)!
+        public static let Highlight = UIColor(named: "NumericInputNumericKeyHighlight", in: BundleToken.bundle, compatibleWith: nil)!
+        public static let Shadow = UIColor(named: "NumericInputNumericKeyShadow", in: BundleToken.bundle, compatibleWith: nil)!
+        public static let Text = UIColor(named: "NumericInputNumericKeyText", in: BundleToken.bundle, compatibleWith: nil)!
       }
     }
     public enum Text {
-      public static let Primary = UIColor(named: "TextPrimary")!
-      public static let Secondary = UIColor(named: "TextSecondary")!
+      public static let Primary = UIColor(named: "TextPrimary", in: BundleToken.bundle, compatibleWith: nil)!
+      public static let Secondary = UIColor(named: "TextSecondary", in: BundleToken.bundle, compatibleWith: nil)!
     }
   }
+}
+
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
 }

--- a/swift-gen/tests/fixtures/colorset/UIColor+Custom.swift
+++ b/swift-gen/tests/fixtures/colorset/UIColor+Custom.swift
@@ -4,25 +4,35 @@ import UIKit
 
 extension UIColor {
   enum Custom {
-    static let LightContentSeparator = UIColor(named: "LightContentSeparator")!
+    static let LightContentSeparator = UIColor(named: "LightContentSeparator", in: BundleToken.bundle, compatibleWith: nil)!
     enum NumericInput {
-      static let Background = UIColor(named: "NumericInputBackground")!
+      static let Background = UIColor(named: "NumericInputBackground", in: BundleToken.bundle, compatibleWith: nil)!
       enum DoneKey {
-        static let Background = UIColor(named: "NumericInputDoneKeyBackground")!
-        static let Highlight = UIColor(named: "NumericInputDoneKeyHighlight")!
-        static let Shadow = UIColor(named: "NumericInputDoneKeyShadow")!
-        static let Text = UIColor(named: "NumericInputDoneKeyText")!
+        static let Background = UIColor(named: "NumericInputDoneKeyBackground", in: BundleToken.bundle, compatibleWith: nil)!
+        static let Highlight = UIColor(named: "NumericInputDoneKeyHighlight", in: BundleToken.bundle, compatibleWith: nil)!
+        static let Shadow = UIColor(named: "NumericInputDoneKeyShadow", in: BundleToken.bundle, compatibleWith: nil)!
+        static let Text = UIColor(named: "NumericInputDoneKeyText", in: BundleToken.bundle, compatibleWith: nil)!
       }
       enum NumericKey {
-        static let Background = UIColor(named: "NumericInputNumericKeyBackground")!
-        static let Highlight = UIColor(named: "NumericInputNumericKeyHighlight")!
-        static let Shadow = UIColor(named: "NumericInputNumericKeyShadow")!
-        static let Text = UIColor(named: "NumericInputNumericKeyText")!
+        static let Background = UIColor(named: "NumericInputNumericKeyBackground", in: BundleToken.bundle, compatibleWith: nil)!
+        static let Highlight = UIColor(named: "NumericInputNumericKeyHighlight", in: BundleToken.bundle, compatibleWith: nil)!
+        static let Shadow = UIColor(named: "NumericInputNumericKeyShadow", in: BundleToken.bundle, compatibleWith: nil)!
+        static let Text = UIColor(named: "NumericInputNumericKeyText", in: BundleToken.bundle, compatibleWith: nil)!
       }
     }
     enum Text {
-      static let Primary = UIColor(named: "TextPrimary")!
-      static let Secondary = UIColor(named: "TextSecondary")!
+      static let Primary = UIColor(named: "TextPrimary", in: BundleToken.bundle, compatibleWith: nil)!
+      static let Secondary = UIColor(named: "TextSecondary", in: BundleToken.bundle, compatibleWith: nil)!
     }
   }
+}
+
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
 }


### PR DESCRIPTION
Allow colors to be generated and used in a Swift Package.

This reflects what is used in [SwiftGen](https://github.com/SwiftGen/SwiftGen/blob/0c67b63f43814a8d7eb71f685f0bf504b03223f3/templates/xcassets/swift5.stencil)

Example SwiftGen generated file:

```swift
internal enum Asset {
  internal static let accentColor = ColorAsset(name: "AccentColor")
}

internal final class ColorAsset {
  internal fileprivate(set) var name: String

  #if os(macOS)
  internal typealias Color = NSColor
  #elseif os(iOS) || os(tvOS) || os(watchOS)
  internal typealias Color = UIColor
  #endif

  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
  internal private(set) lazy var color: Color = {
    guard let color = Color(asset: self) else {
      fatalError("Unable to load color asset named \(name).")
    }
    return color
  }()

  #if os(iOS) || os(tvOS)
  @available(iOS 11.0, tvOS 11.0, *)
  internal func color(compatibleWith traitCollection: UITraitCollection) -> Color {
    let bundle = BundleToken.bundle
    guard let color = Color(named: name, in: bundle, compatibleWith: traitCollection) else {
      fatalError("Unable to load color asset named \(name).")
    }
    return color
  }
  #endif

  fileprivate init(name: String) {
    self.name = name
  }
}

internal extension ColorAsset.Color {
  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
  convenience init?(asset: ColorAsset) {
    let bundle = BundleToken.bundle
    #if os(iOS) || os(tvOS)
    self.init(named: asset.name, in: bundle, compatibleWith: nil)
    #elseif os(macOS)
    self.init(named: NSColor.Name(asset.name), bundle: bundle)
    #elseif os(watchOS)
    self.init(named: asset.name)
    #endif
  }
}

// swiftlint:disable convenience_type
private final class BundleToken {
  static let bundle: Bundle = {
    #if SWIFT_PACKAGE
    return Bundle.module
    #else
    return Bundle(for: BundleToken.self)
    #endif
  }()
}
// swiftlint:enable convenience_type
```
