### PR TITLE
Fix spacing formatting before ":"

### DIFF
--- a/asset-catalog/src/asset_catalog.rs
+++ b/asset-catalog/src/asset_catalog.rs
@@ -155,12 +155,12 @@ fn write_declaration(
     |value: &mut serde_json::value::Value, color: &Color| -> Result<(), Error> {
       let arr = value["colors"].as_array_mut().unwrap();
       arr.push(json!({
-        "idiom" : "universal",
-        "appearances" : [{
-          "appearance" : "luminosity",
-          "value" : "dark"
+        "idiom": "universal",
+        "appearances": [{
+          "appearance": "luminosity",
+          "value": "dark"
         }],
-        "color" : {
+        "color": {
           "color-space" : config.color_space.to_string(),
           "components" : components(color)
         }


### PR DESCRIPTION
Fix for issue: https://github.com/nesium/xcode-color-assets/issues/12#issue-1023498270